### PR TITLE
feat(ops): enable lifecycle and readiness probes

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -9,7 +9,7 @@ description: Enable the use of Armory Services with your privatly networked reso
 version: "0.0.0-iam-am-changed-in-ci"
 
 # The Agent Version
-appVersion: v2.0.2
+appVersion: v2.1.0
 
 maintainers:
   - name: Armory Engineering

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -25,6 +25,14 @@ spec:
         - name: remote-network-agent
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          readinessProbe:
+            httpGet:
+              path: /health/readiness
+              port: 8080
+          livenessProbe:
+            httpGet:
+              path: /health/liveness
+              port: 8080
           env:
             {{- if .Values.proxy.enabled -}}
               {{- include "armory-remote-network-agent.proxy-settings" . | nindent 12 }}


### PR DESCRIPTION
Enables the features in https://github.com/armory-io/remote-network-agent/pull/2 
