### PR TITLE
chore(agent): bump version

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -9,7 +9,7 @@ description: Enable the use of Armory Services with your privatly networked reso
 version: "0.0.0-iam-am-changed-in-ci"
 
 # The Agent Version
-appVersion: v2.1.0
+appVersion: v2.1.2
 
 maintainers:
   - name: Armory Engineering


### PR DESCRIPTION
This PR bumps the Agent version to v2.1.2, which has a fix to make the error messages around K8s secrets more clear when referencing a secret key that doesn't exist.