### PR TITLE
chore(ops): bump start-up probe delay to 60 seconds

### DIFF
--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -34,7 +34,7 @@ spec:
               path: /health/liveness
               port: 8080
           startupProbe:
-            initialDelaySeconds: 30
+            initialDelaySeconds: 60
             periodSeconds: 10
             timeoutSeconds: 1
             successThreshold: 1


### PR DESCRIPTION
30 Seconds works fine, but I noticed in some slow clusters it can take about minute for the agent to initialize completely.