### PR TITLE
feat(deployment): add default cpu and memory requests/limits

### DIFF
--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -42,6 +42,13 @@ spec:
             httpGet:
               path: /health/liveness
               port: 8080
+          resources:
+            requests:
+              memory: "1500Mi"
+              cpu: "2000m"
+            limits:
+              memory: "2500Mi"
+              cpu: "2500m"
           env:
             {{- if .Values.proxy.enabled -}}
               {{- include "armory-remote-network-agent.proxy-settings" . | nindent 12 }}
@@ -49,6 +56,8 @@ spec:
             {{- include "armory-remote-network-agent.pod-env-vars" . | nindent 12 }}
             - name: ADDITIONAL_JVM_OPTS
               value: >-
+                -Xms1000M
+                -Xmx1000M
                 -Darmory.iam.oidc.client-id={{ include "armory-remote-network-agent.client-id" . }}
                 -Darmory.iam.oidc.client-secret={{ include "armory-remote-network-agent.client-secret" . }}
                 {{- if .Values.kubernetes.enableClusterAccountMode }}


### PR DESCRIPTION
Set the request resources based on what Justin recommended. Used best practice guidance to set resource limits. Set JVM request and max (`-Xms`,`-Xmx`) to be roughly 66% of requested memory amount (based on [this](https://akobor.me/posts/heap-size-and-resource-limits-in-kubernetes-for-jvm-applications) article).

Tested this using the `--dry-run` flag to verify that the resulting configuration looked correct.