### PR TITLE
feat(deployment): pass in resource request limits as values

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,19 @@ helm upgrade --install armory-rna armory/remote-network-agent \
 ```
 
 ## Installation with CPU and memory request limits 
+
+### Note:
+
+These memory and CPU limits can only be set to an amount that is higher than the defaults. `podMemoryRequest` and `podMemoryLimit` accepts `Mi` (for Mebibytes) and `M` (for Megabytes) units. `podCPURequest` and `podCPULimit` accept `m` for (millicpu) units.
+
+### Defaults:
+```
+podMemoryRequest: "1500M"
+podMemoryLimit: "2500M"
+podCPURequest: "2000m"
+podCPULimit: "2500m"
+```
+
 ```shell
 # Optionally Add Armory Chart repo, if you haven't
 helm repo add armory https://armory.jfrog.io/artifactory/charts

--- a/README.md
+++ b/README.md
@@ -71,14 +71,26 @@ helm upgrade --install armory-rna armory/remote-network-agent \
 
 ### Note:
 
-These memory and CPU limits can only be set to an amount that is higher than the defaults. `podMemoryRequest` and `podMemoryLimit` accepts `Mi` (for Mebibytes) and `M` (for Megabytes) units. `podCPURequest` and `podCPULimit` accept `m` for (millicpu) units.
+The defaults map to performant values that can be overriden. Increasing the requests and limits is useful when vertical scaling the RNA pods, but horizontal scaling is another approach to increase performance.
+
+ `podMemoryRequest` and `podMemoryLimit` accepts `Mi` (for Mebibytes) and `M` (for Megabytes) units. `podCPURequest` and `podCPULimit` accept `m` for (millicpu) units.
 
 ### Defaults:
 ```
 podMemoryRequest: "1500M"
 podMemoryLimit: "2500M"
-podCPURequest: "2000m"
-podCPULimit: "2500m"
+podCPURequest: "500m"
+podCPULimit: "7500m"
+```
+
+
+You cannot set the requests and limits below the following values:
+
+```
+podMemoryRequest: "500Mi"
+podMemoryLimit: "750Mi"
+podCPURequest: "500m"
+podCPULimit: "750m"
 ```
 
 ```shell

--- a/README.md
+++ b/README.md
@@ -67,6 +67,23 @@ helm upgrade --install armory-rna armory/remote-network-agent \
     --namespace armory-rna
 ```
 
+## Installation with CPU and memory request limits 
+```shell
+# Optionally Add Armory Chart repo, if you haven't
+helm repo add armory https://armory.jfrog.io/artifactory/charts
+# Update repo to fetch latest armory charts
+helm repo update
+# Install or Upgrade armory rna chart
+helm upgrade --install armory-rna armory/remote-network-agent \
+    --set clientId='encrypted:k8s!n:rna-client-credentials!k:client-id' \
+    --set clientSecret='encrypted:k8s!n:rna-client-credentials!k:client-secret' \
+    --set memoryRequest=2000m \
+    --set memoryLimit=2500Mi \
+    --set cpuRequest=1500Mi \
+    --set cpuLimit=2500m \
+    --namespace armory-rna
+```
+
 # Advanced Usage
 
 Copy, read, and then edit the [values.yaml](values.yaml) file.

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -128,3 +128,42 @@ annotations:
         {{- end }}
     {{- end }}
 {{- end }}
+
+{{/* function for setting resource limits */}}
+{{- define "armory-remote-network-agent.resource-request-limits" }}
+  {{- $memoryRequest := .Values.memoryRequest -}}
+  {{- $cpuRequest := .Values.cpuRequest -}}
+  {{- $memoryLimit := .Values.memoryLimit -}}
+  {{- $cpuLimit := .Values.cpuLimit -}}
+  {{- if (empty $memoryRequest) }}
+    {{- $memoryRequest = "1500Mi" -}}
+  {{- end }}
+  {{- if (empty $cpuRequest) }}
+    {{- $cpuRequest = "2000m" -}}
+  {{- end }}
+  {{- if (empty $memoryLimit) }}
+    {{- $memoryLimit = "2500Mi" -}}
+  {{- end }}
+  {{- if (empty $cpuLimit) }}
+    {{- $cpuLimit = "2500m" -}}
+  {{- end }}
+  {{- if not (regexMatch "^([+-]?[0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$" $memoryRequest)}}
+    {{- fail "value for memoryRequest is not valid" }}
+  {{- end }}
+  {{- if not (regexMatch "^([+-]?[0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$" $cpuRequest)}}
+    {{- fail "value for cpuRequest is not valid" }}
+  {{- end }}
+  {{- if not (regexMatch "^([+-]?[0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$" $memoryLimit) }}
+    {{- fail "value for memoryLimit is not valid" }}
+  {{- end }}
+  {{- if not (regexMatch "^([+-]?[0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$" $cpuLimit)}}
+    {{- fail "value for cpuLimit is not valid" }}
+  {{- end }}
+  resources:
+    requests:
+      memory: {{ $memoryRequest }}
+      cpu: {{ $cpuRequest }}
+    limits:
+      memory: {{ $memoryLimit }}
+      cpu: {{ $cpuLimit }}
+{{- end }}

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -129,41 +129,103 @@ annotations:
     {{- end }}
 {{- end }}
 
-{{/* function for setting resource limits */}}
-{{- define "armory-remote-network-agent.resource-request-limits" }}
-  {{- $memoryRequest := .Values.memoryRequest -}}
-  {{- $cpuRequest := .Values.cpuRequest -}}
-  {{- $memoryLimit := .Values.memoryLimit -}}
-  {{- $cpuLimit := .Values.cpuLimit -}}
-  {{- if (empty $memoryRequest) }}
-    {{- $memoryRequest = "1500Mi" -}}
+{{/* function for setting pod resource limits */}}
+{{- define "armory-remote-network-agent.request-limits" }}
+  {{- $podMemoryRequest := .Values.podMemoryRequest -}}
+  {{- $podCPURequest := .Values.podCPURequest -}}
+  {{- $podMemoryLimit := .Values.podMemoryLimit -}}
+  {{- $podCPULimit := .Values.podCPULimit -}}
+  {{/* set defaults */}}
+  {{- if (empty $podMemoryRequest) }}
+    {{- $podMemoryRequest = "1500Mi" -}}
   {{- end }}
-  {{- if (empty $cpuRequest) }}
-    {{- $cpuRequest = "2000m" -}}
+  {{- if (empty $podCPURequest) }}
+    {{- $podCPURequest = "2000m" -}}
   {{- end }}
-  {{- if (empty $memoryLimit) }}
-    {{- $memoryLimit = "2500Mi" -}}
+  {{- if (empty $podMemoryLimit) }}
+    {{- $podMemoryLimit = "2500Mi" -}}
   {{- end }}
-  {{- if (empty $cpuLimit) }}
-    {{- $cpuLimit = "2500m" -}}
+  {{- if (empty $podCPULimit) }}
+    {{- $podCPULimit = "2500m" -}}
   {{- end }}
-  {{- if not (regexMatch "^([+-]?[0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$" $memoryRequest)}}
-    {{- fail "value for memoryRequest is not valid" }}
+  {{/* validate memory and cpu units */}}
+  {{- $memoryReqWithUnit := regexFind "^([0-9.]+)Mi|M$" $podMemoryRequest -}}
+  {{- if (empty $memoryReqWithUnit) }}
+    {{- fail "podMemoryRequest value is not valid, please use Mi or M units" }}
   {{- end }}
-  {{- if not (regexMatch "^([+-]?[0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$" $cpuRequest)}}
-    {{- fail "value for cpuRequest is not valid" }}
+  {{- $memoryReq := regexFind "^([0-9.]+)" $podMemoryRequest -}}
+  {{- $cpuReqWithUnit := regexFind "^([0-9.]+)m$" $podCPURequest -}}
+  {{- if (empty $cpuReqWithUnit) }}
+    {{- fail "podCPURequest value is not valid, please use m units" }}
   {{- end }}
-  {{- if not (regexMatch "^([+-]?[0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$" $memoryLimit) }}
-    {{- fail "value for memoryLimit is not valid" }}
+  {{- $cpuReq := regexFind "^([0-9.]+)" $podCPURequest -}}
+  {{- $memoryLimitWithUnit := regexFind "^([0-9.]+)Mi|M$" $podMemoryLimit -}}
+  {{- if (empty $memoryLimitWithUnit) }}
+    {{- fail "podMemoryLimit value is not valid, please use Mi or M units" }}
   {{- end }}
-  {{- if not (regexMatch "^([+-]?[0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$" $cpuLimit)}}
-    {{- fail "value for cpuLimit is not valid" }}
+  {{- $memoryLimit := regexFind "^([0-9.]+)" $podMemoryLimit -}}
+  {{- $cpuLimitWithUnit := regexFind "^([0-9.]+)m$" $podCPULimit -}}
+  {{- if (empty $cpuLimitWithUnit) }}
+    {{- fail "podCPULimit value is not valid, please use m units" }}
   {{- end }}
+  {{- $cpuLimit := regexFind "^([0-9.]+)" $podCPULimit -}}
+  {{/* do memory unit conversions between Mib and M */}}
+  {{- $memoryReqUnit := "M" -}}
+  {{- if contains "Mi" $podMemoryRequest }}
+    {{- $memoryReqUnit = "Mi" }}
+  {{- end }}
+  {{- $memoryLimitUnit := "M" -}}
+  {{- if contains "Mi" $podMemoryLimit }}
+    {{- $memoryLimitUnit = "Mi" }}
+  {{- end }}
+  {{ $memoryReqMi := float64 1500 -}}
+  {{ $memoryReqM := float64 1573 -}}
+  {{- if eq $memoryReqUnit "M"}}
+    {{ $memoryReqMi = div (mul $memoryReq 95) 100 -}}
+    {{ $memoryReqM = float64 $memoryReq -}}
+  {{- else if eq $memoryReqUnit "Mi"}}
+    {{ $memoryReqMi = float64 $memoryReq -}}
+    {{ $memoryReqM = div (mul 105 (float64 $memoryReq)) 100 -}}
+  {{- end }}
+  {{ $memoryLimitMi := float64 2500 -}}
+  {{ $memoryLimitM := float64 2621 -}}
+  {{- if eq $memoryLimitUnit "M"}}
+    {{ $memoryLimitMi = div (mul (float64 $memoryLimit) 95) 100 -}}
+    {{ $memoryLimitM = float64 $memoryLimit -}}
+  {{- else if eq $memoryLimitUnit "Mi"}}
+    {{ $memoryLimitMi = float64 $memoryLimit -}}
+    {{ $memoryLimitM = div (mul 105 (float64 $memoryLimit)) 100 -}}
+  {{- end }}
+  {{/* validate min values for memory and cpu */}}
+  {{- if gt (float64 $memoryReqMi) (float64 $memoryLimitMi) }}
+    {{- fail "podMemoryLimit must be greater than podMemoryRequest" }}
+  {{- end }}
+  {{- if gt $cpuReq $cpuLimit }}
+    {{- fail "podCPULimit must be greater than podCPURequest" }}
+  {{- end }}
+  {{- if gt (float64 1500) (float64 $memoryReqMi) }}
+    {{- fail "podMemoryReq must be greater than 1500Mi" }}
+  {{- end }}
+  {{- if gt (float64 2500) (float64 $memoryLimitMi) }}
+    {{- fail "podMemoryLimit must be greater than 2500Mi" }}
+  {{- end }}
+  {{- if gt 2000 (int $cpuReq) }}
+    {{- fail "podCPURequest must be greater than 2000m" }}
+  {{- end }}
+  {{- if gt 2500 (int $cpuLimit) }}
+    {{- fail "podCPULimit must be greater than 2500m" }}
+  {{- end }}
+  {{- if eq .Type "pod" -}}
   resources:
     requests:
-      memory: {{ $memoryRequest }}
-      cpu: {{ $cpuRequest }}
+      memory: {{ $memoryReqWithUnit }}
+      cpu: {{ $cpuReqWithUnit }}
     limits:
-      memory: {{ $memoryLimit }}
-      cpu: {{ $cpuLimit }}
+      memory: {{ $memoryLimitWithUnit }}
+      cpu: {{ $cpuLimitWithUnit }}
+  {{- else if eq .Type "jvm"}}
+    {{ $heapSize := div (mul 66 (float64 $memoryReqM)) 100 }}
+    -Xms{{ $heapSize }}M
+    -Xmx{{ $heapSize }}M
+  {{- end }}
 {{- end }}

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -140,13 +140,13 @@ annotations:
     {{- $podMemoryRequest = "1500Mi" -}}
   {{- end }}
   {{- if (empty $podCPURequest) }}
-    {{- $podCPURequest = "2000m" -}}
+    {{- $podCPURequest = "500m" -}}
   {{- end }}
   {{- if (empty $podMemoryLimit) }}
     {{- $podMemoryLimit = "2500Mi" -}}
   {{- end }}
   {{- if (empty $podCPULimit) }}
-    {{- $podCPULimit = "2500m" -}}
+    {{- $podCPULimit = "750m" -}}
   {{- end }}
   {{/* validate memory and cpu units */}}
   {{- $memoryReqWithUnit := regexFind "^([0-9.]+)Mi|M$" $podMemoryRequest -}}
@@ -203,17 +203,17 @@ annotations:
   {{- if gt $cpuReq $cpuLimit }}
     {{- fail "podCPULimit must be greater than podCPURequest" }}
   {{- end }}
-  {{- if gt (float64 1500) (float64 $memoryReqMi) }}
-    {{- fail "podMemoryReq must be greater than 1500Mi" }}
+  {{- if gt (float64 500) (float64 $memoryReqMi) }}
+    {{- fail "podMemoryRequest must be greater than 500Mi" }}
   {{- end }}
-  {{- if gt (float64 2500) (float64 $memoryLimitMi) }}
-    {{- fail "podMemoryLimit must be greater than 2500Mi" }}
+  {{- if gt (float64 750) (float64 $memoryLimitMi) }}
+    {{- fail "podMemoryLimit must be greater than 750Mi" }}
   {{- end }}
-  {{- if gt 2000 (int $cpuReq) }}
-    {{- fail "podCPURequest must be greater than 2000m" }}
+  {{- if gt 500 (int $cpuReq) }}
+    {{- fail "podCPURequest must be greater than 500m" }}
   {{- end }}
-  {{- if gt 2500 (int $cpuLimit) }}
-    {{- fail "podCPULimit must be greater than 2500m" }}
+  {{- if gt 750 (int $cpuLimit) }}
+    {{- fail "podCPULimit must be greater than 750m" }}
   {{- end }}
   {{- if eq .Type "pod" -}}
   resources:

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -42,7 +42,8 @@ spec:
             httpGet:
               path: /health/liveness
               port: 8080
-          {{- include "armory-remote-network-agent.resource-request-limits" . | nindent 8 }}
+          {{$podData := dict "Values" .Values "Type" "pod"}}
+          {{- include "armory-remote-network-agent.request-limits" $podData | nindent 8 | trim }}
           env:
             {{- if .Values.proxy.enabled -}}
               {{- include "armory-remote-network-agent.proxy-settings" . | nindent 12 }}
@@ -50,8 +51,8 @@ spec:
             {{- include "armory-remote-network-agent.pod-env-vars" . | nindent 12 }}
             - name: ADDITIONAL_JVM_OPTS
               value: >-
-                -Xms1000M
-                -Xmx1000M
+                {{$jvmData := dict "Values" .Values "Type" "jvm"}}
+                {{- include "armory-remote-network-agent.request-limits" $jvmData | nindent 12 | trim }}
                 -Darmory.iam.oidc.client-id={{ include "armory-remote-network-agent.client-id" . }}
                 -Darmory.iam.oidc.client-secret={{ include "armory-remote-network-agent.client-secret" . }}
                 {{- if .Values.kubernetes.enableClusterAccountMode }}

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -42,6 +42,7 @@ spec:
             httpGet:
               path: /health/liveness
               port: 8080
+          {{- include "armory-remote-network-agent.resource-request-limits" . | nindent 8 }}
           env:
             {{- if .Values.proxy.enabled -}}
               {{- include "armory-remote-network-agent.proxy-settings" . | nindent 12 }}

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -50,6 +50,8 @@ spec:
             {{- include "armory-remote-network-agent.pod-env-vars" . | nindent 12 }}
             - name: ADDITIONAL_JVM_OPTS
               value: >-
+                -Xms1000M
+                -Xmx1000M
                 -Darmory.iam.oidc.client-id={{ include "armory-remote-network-agent.client-id" . }}
                 -Darmory.iam.oidc.client-secret={{ include "armory-remote-network-agent.client-secret" . }}
                 {{- if .Values.kubernetes.enableClusterAccountMode }}

--- a/tests/deployment_test.yaml
+++ b/tests/deployment_test.yaml
@@ -178,13 +178,13 @@ tests:
           value: "1500Mi"
       - equal:
           path: spec.template.spec.containers[0].resources.requests.cpu
-          value: "2000m"
+          value: "500m"
       - equal:
           path: spec.template.spec.containers[0].resources.limits.memory
           value: "2500Mi"
       - equal:
           path: spec.template.spec.containers[0].resources.limits.cpu
-          value: "2500m"
+          value: "750m"
   - it: sets the resource request limits when set
     set:
       clientId: encrypted:k8s!n:rna-client-credentials!k:client-id
@@ -265,57 +265,58 @@ tests:
     asserts:
       - failedTemplate:
           errorMessage: podCPULimit must be greater than podCPURequest
-  - it:  fails when memory request is lower than default (Mi unit)
+  - it:  fails when memory request is lower than lower bound (Mi unit)
     set:
       clientId: encrypted:k8s!n:rna-client-credentials!k:client-id
       clientSecret: encrypted:k8s!n:rna-client-credentials!k:client-secret
       podMemoryRequest: 1Mi
     asserts:
       - failedTemplate:
-          errorMessage: podMemoryReq must be greater than 1500Mi
-  - it: fails when memory request is lower than default (M unit)
+          errorMessage: podMemoryRequest must be greater than 500Mi
+  - it: fails when memory request is lower than lower bound (M unit)
     set:
       clientId: encrypted:k8s!n:rna-client-credentials!k:client-id
       clientSecret: encrypted:k8s!n:rna-client-credentials!k:client-secret
       podMemoryRequest: 1M
     asserts:
       - failedTemplate:
-          errorMessage: podMemoryReq must be greater than 1500Mi
-  - it: fails when cpu request is lower than default
+          errorMessage: podMemoryRequest must be greater than 500Mi
+  - it: fails when cpu request is lower than lower bound
     set:
       clientId: encrypted:k8s!n:rna-client-credentials!k:client-id
       clientSecret: encrypted:k8s!n:rna-client-credentials!k:client-secret
       podCPURequest: 1m
+      podCPULimit: 1000m
     asserts:
       - failedTemplate:
-          errorMessage: podCPURequest must be greater than 2000m 
-  - it: fails when memory limit is lower than default (M unit)
+          errorMessage: podCPURequest must be greater than 500m 
+  - it: fails when memory limit is lower than lower bound (M unit)
     set:
       clientId: encrypted:k8s!n:rna-client-credentials!k:client-id
       clientSecret: encrypted:k8s!n:rna-client-credentials!k:client-secret
-      podMemoryLimit: 2000M
-      podMemoryRequest: 1800M
+      podMemoryRequest: 650M
+      podMemoryLimit: 700M
     asserts:
       - failedTemplate:
-          errorMessage: podMemoryLimit must be greater than 2500Mi
-  - it: fails when memory limit is lower than default (Mi unit)
+          errorMessage: podMemoryLimit must be greater than 750Mi
+  - it: fails when memory limit is lower than lower bound (Mi unit)
     set:
       clientId: encrypted:k8s!n:rna-client-credentials!k:client-id
       clientSecret: encrypted:k8s!n:rna-client-credentials!k:client-secret
-      podMemoryLimit: 2000Mi
-      podMemoryRequest: 1800Mi
+      podMemoryRequest: 501Mi
+      podMemoryLimit: 600Mi
     asserts:
       - failedTemplate:
-          errorMessage: podMemoryLimit must be greater than 2500Mi
-  - it: fails when cpu limit is lower than the default
+          errorMessage: podMemoryLimit must be greater than 750Mi
+  - it: fails when cpu limit is lower than the lower bound
     set:
       clientId: encrypted:k8s!n:rna-client-credentials!k:client-id
       clientSecret: encrypted:k8s!n:rna-client-credentials!k:client-secret
-      podCPURequest: 2001m
-      podCPULimit: 2002m
+      podCPURequest: 600m
+      podCPULimit: 700m
     asserts:
       - failedTemplate:
-          errorMessage: podCPULimit must be greater than 2500m
+          errorMessage: podCPULimit must be greater than 750m
   - it: adds heap size as 66% of pod memory request to the ADDITIONAL_OPTS env var
     set:
       clientId: muh-client-id

--- a/tests/deployment_test.yaml
+++ b/tests/deployment_test.yaml
@@ -168,3 +168,76 @@ tests:
       - matchRegex:
           path: spec.template.spec.containers[0].env[0].value
           pattern: .*?-Dfoo=bar.*?
+  - it: sets the resource request limits to defaults
+    set:
+      clientId: encrypted:k8s!n:rna-client-credentials!k:client-id
+      clientSecret: encrypted:k8s!n:rna-client-credentials!k:client-secret
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].resources.requests.memory
+          value: "1500Mi"
+      - equal:
+          path: spec.template.spec.containers[0].resources.requests.cpu
+          value: "2000m"
+      - equal:
+          path: spec.template.spec.containers[0].resources.limits.memory
+          value: "2500Mi"
+      - equal:
+          path: spec.template.spec.containers[0].resources.limits.cpu
+          value: "2500m"
+  - it: sets the resource request limits when set
+    set:
+      clientId: encrypted:k8s!n:rna-client-credentials!k:client-id
+      clientSecret: encrypted:k8s!n:rna-client-credentials!k:client-secret
+      memoryRequest: 1Mi
+      memoryLimit: 2Mi
+      cpuRequest: 2m
+      cpuLimit: 3m
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].resources.requests.memory
+          value: "1Mi"
+      - equal:
+          path: spec.template.spec.containers[0].resources.requests.cpu
+          value: "2m"
+      - equal:
+          path: spec.template.spec.containers[0].resources.limits.memory
+          value: "2Mi"
+      - equal:
+          path: spec.template.spec.containers[0].resources.limits.cpu
+          value: "3m"
+  - it: fails when invalid memory request set
+    set:
+      clientId: encrypted:k8s!n:rna-client-credentials!k:client-id
+      clientSecret: encrypted:k8s!n:rna-client-credentials!k:client-secret
+      memoryRequest: 1Potato
+      memoryLimit: 2Mi
+      cpuRequest: 2m
+      cpuLimit: 3m
+    asserts:
+      - failedTemplate:
+          errorMessage: value for memoryRequest is not valid
+  - it: fails when invalid cpu request set
+    set:
+      clientId: encrypted:k8s!n:rna-client-credentials!k:client-id
+      clientSecret: encrypted:k8s!n:rna-client-credentials!k:client-secret
+      cpuRequest: 1Potato
+    asserts:
+      - failedTemplate:
+          errorMessage: value for cpuRequest is not valid
+  - it: fails when invalid memory limit set
+    set:
+      clientId: encrypted:k8s!n:rna-client-credentials!k:client-id
+      clientSecret: encrypted:k8s!n:rna-client-credentials!k:client-secret
+      memoryLimit: 1Potato
+    asserts:
+      - failedTemplate:
+          errorMessage: value for memoryLimit is not valid
+  - it: fails when invalid cpu limit set
+    set:
+      clientId: encrypted:k8s!n:rna-client-credentials!k:client-id
+      clientSecret: encrypted:k8s!n:rna-client-credentials!k:client-secret
+      cpuLimit: 1Potato
+    asserts:
+      - failedTemplate:
+          errorMessage: value for cpuLimit is not valid

--- a/tests/deployment_test.yaml
+++ b/tests/deployment_test.yaml
@@ -189,55 +189,148 @@ tests:
     set:
       clientId: encrypted:k8s!n:rna-client-credentials!k:client-id
       clientSecret: encrypted:k8s!n:rna-client-credentials!k:client-secret
-      memoryRequest: 1Mi
-      memoryLimit: 2Mi
-      cpuRequest: 2m
-      cpuLimit: 3m
+      podMemoryRequest: 1600Mi
+      podMemoryLimit: 2600Mi
+      podCPURequest: 2100m
+      podCPULimit: 2600m
     asserts:
       - equal:
           path: spec.template.spec.containers[0].resources.requests.memory
-          value: "1Mi"
+          value: "1600Mi"
       - equal:
           path: spec.template.spec.containers[0].resources.requests.cpu
-          value: "2m"
+          value: "2100m"
       - equal:
           path: spec.template.spec.containers[0].resources.limits.memory
-          value: "2Mi"
+          value: "2600Mi"
       - equal:
           path: spec.template.spec.containers[0].resources.limits.cpu
-          value: "3m"
+          value: "2600m"
   - it: fails when invalid memory request set
     set:
       clientId: encrypted:k8s!n:rna-client-credentials!k:client-id
       clientSecret: encrypted:k8s!n:rna-client-credentials!k:client-secret
-      memoryRequest: 1Potato
-      memoryLimit: 2Mi
-      cpuRequest: 2m
-      cpuLimit: 3m
+      podMemoryRequest: 1Potato
     asserts:
       - failedTemplate:
-          errorMessage: value for memoryRequest is not valid
+          errorMessage: podMemoryRequest value is not valid, please use Mi or M units
   - it: fails when invalid cpu request set
     set:
       clientId: encrypted:k8s!n:rna-client-credentials!k:client-id
       clientSecret: encrypted:k8s!n:rna-client-credentials!k:client-secret
-      cpuRequest: 1Potato
+      podCPURequest: 1Potato
     asserts:
       - failedTemplate:
-          errorMessage: value for cpuRequest is not valid
+          errorMessage: podCPURequest value is not valid, please use m units
   - it: fails when invalid memory limit set
     set:
       clientId: encrypted:k8s!n:rna-client-credentials!k:client-id
       clientSecret: encrypted:k8s!n:rna-client-credentials!k:client-secret
-      memoryLimit: 1Potato
+      podMemoryLimit: 1Potato
     asserts:
       - failedTemplate:
-          errorMessage: value for memoryLimit is not valid
+          errorMessage: podMemoryLimit value is not valid, please use Mi or M units
   - it: fails when invalid cpu limit set
     set:
       clientId: encrypted:k8s!n:rna-client-credentials!k:client-id
       clientSecret: encrypted:k8s!n:rna-client-credentials!k:client-secret
-      cpuLimit: 1Potato
+      podCPULimit: 1Potato
     asserts:
       - failedTemplate:
-          errorMessage: value for cpuLimit is not valid
+          errorMessage: podCPULimit value is not valid, please use m units
+  - it: fails when memory request is lower than memory limit (Mi unit)
+    set:
+      clientId: encrypted:k8s!n:rna-client-credentials!k:client-id
+      clientSecret: encrypted:k8s!n:rna-client-credentials!k:client-secret
+      podMemoryRequest: 2600Mi
+      podMemoryLimit: 1600Mi
+    asserts:
+      - failedTemplate:
+          errorMessage: podMemoryLimit must be greater than podMemoryRequest
+  - it: fails when memory request is lower than memory limit (M unit)
+    set:
+      clientId: encrypted:k8s!n:rna-client-credentials!k:client-id
+      clientSecret: encrypted:k8s!n:rna-client-credentials!k:client-secret
+      podMemoryRequest: 2600M
+      podMemoryLimit: 1600M
+    asserts:
+      - failedTemplate:
+          errorMessage: podMemoryLimit must be greater than podMemoryRequest
+  - it: fails when cpu request is lower than cpu limit
+    set:
+      clientId: encrypted:k8s!n:rna-client-credentials!k:client-id
+      clientSecret: encrypted:k8s!n:rna-client-credentials!k:client-secret
+      podCPURequest: 3500m
+      podCPULimit: 3000m
+    asserts:
+      - failedTemplate:
+          errorMessage: podCPULimit must be greater than podCPURequest
+  - it:  fails when memory request is lower than default (Mi unit)
+    set:
+      clientId: encrypted:k8s!n:rna-client-credentials!k:client-id
+      clientSecret: encrypted:k8s!n:rna-client-credentials!k:client-secret
+      podMemoryRequest: 1Mi
+    asserts:
+      - failedTemplate:
+          errorMessage: podMemoryReq must be greater than 1500Mi
+  - it: fails when memory request is lower than default (M unit)
+    set:
+      clientId: encrypted:k8s!n:rna-client-credentials!k:client-id
+      clientSecret: encrypted:k8s!n:rna-client-credentials!k:client-secret
+      podMemoryRequest: 1M
+    asserts:
+      - failedTemplate:
+          errorMessage: podMemoryReq must be greater than 1500Mi
+  - it: fails when cpu request is lower than default
+    set:
+      clientId: encrypted:k8s!n:rna-client-credentials!k:client-id
+      clientSecret: encrypted:k8s!n:rna-client-credentials!k:client-secret
+      podCPURequest: 1m
+    asserts:
+      - failedTemplate:
+          errorMessage: podCPURequest must be greater than 2000m 
+  - it: fails when memory limit is lower than default (M unit)
+    set:
+      clientId: encrypted:k8s!n:rna-client-credentials!k:client-id
+      clientSecret: encrypted:k8s!n:rna-client-credentials!k:client-secret
+      podMemoryLimit: 2000M
+      podMemoryRequest: 1800M
+    asserts:
+      - failedTemplate:
+          errorMessage: podMemoryLimit must be greater than 2500Mi
+  - it: fails when memory limit is lower than default (Mi unit)
+    set:
+      clientId: encrypted:k8s!n:rna-client-credentials!k:client-id
+      clientSecret: encrypted:k8s!n:rna-client-credentials!k:client-secret
+      podMemoryLimit: 2000Mi
+      podMemoryRequest: 1800Mi
+    asserts:
+      - failedTemplate:
+          errorMessage: podMemoryLimit must be greater than 2500Mi
+  - it: fails when cpu limit is lower than the default
+    set:
+      clientId: encrypted:k8s!n:rna-client-credentials!k:client-id
+      clientSecret: encrypted:k8s!n:rna-client-credentials!k:client-secret
+      podCPURequest: 2001m
+      podCPULimit: 2002m
+    asserts:
+      - failedTemplate:
+          errorMessage: podCPULimit must be greater than 2500m
+  - it: adds heap size as 66% of pod memory request to the ADDITIONAL_OPTS env var
+    set:
+      clientId: muh-client-id
+      clientSecret: muh-client-secret
+      podMemoryRequest: 1600Mi
+      podMemoryLimit: 2600Mi
+      podCPURequest: 2100m
+      podCPULimit: 2600m
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].env[0].name
+          value: "ADDITIONAL_JVM_OPTS"
+      - matchRegex:
+          path: spec.template.spec.containers[0].env[0].value
+          pattern: .*?Xms1108M.*?
+      - matchRegex:
+          path: spec.template.spec.containers[0].env[0].value
+          pattern: .*?Xmx1108M.*?

--- a/values.yaml
+++ b/values.yaml
@@ -106,5 +106,5 @@ extraOpts: []
 # Resource management for the remote-network-agent pods
 podMemoryRequest: "1500Mi"
 podMemoryLimit: "2500Mi"
-podCPURequest: "2000m"
-podCPULimit: "2500m"
+podCPURequest: "500m"
+podCPULimit: "750m"

--- a/values.yaml
+++ b/values.yaml
@@ -103,8 +103,8 @@ podAnnotations: {}
 # - "-Dlogging.level.io.armory.cloud.wormhole=DEBUG"
 extraOpts: []
 
-# Resource management for the remote-network-agent container
-memoryRequest: "1500Mi"
-memoryLimit: "2500Mi"
-cpuRequest: "2000m"
-cpuLimit: "2500m"
+# Resource management for the remote-network-agent pods
+podMemoryRequest: "1500Mi"
+podMemoryLimit: "2500Mi"
+podCPURequest: "2000m"
+podCPULimit: "2500m"

--- a/values.yaml
+++ b/values.yaml
@@ -103,3 +103,8 @@ podAnnotations: {}
 # - "-Dlogging.level.io.armory.cloud.wormhole=DEBUG"
 extraOpts: []
 
+# Resource management for the remote-network-agent container
+memoryRequest: "1500Mi"
+memoryLimit: "2500Mi"
+cpuRequest: "2000m"
+cpuLimit: "2500m"


### PR DESCRIPTION
Dependent on armory-io/remote-network-agent-helm-chart#19

The new values that can be set are `podMemoryRequest`, `podMemoryLimit`, `podCPURequest`, `podCPULimit`. They map to `pec.template.spec.containers[0].resources`. Will revert to the defaults if nothing is set or error out if set to an amount less than the defaults.

The jvm heap size opts are also calculated as 66% of the `podMemoryRequest`. Jacob's find- https://akobor.me/posts/heap-size-and-resource-limits-in-kubernetes-for-jvm-applications