### PR TITLE
docs(chore): proofread comments

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -8,7 +8,7 @@ description: Enable the use of Armory Services with your privately networked res
 # The Chart Version
 version: "0.0.0-iam-am-changed-in-ci"
 
-# The Agent Version
+# The Remote Network Agent Version
 appVersion: v3.0.31
 
 maintainers:

--- a/README.md
+++ b/README.md
@@ -3,17 +3,19 @@ Helm Chart for Armory's Remote Network Agent
 
 # Basic Usage
 
-See [Advanced Configuration](#advanced-configuration) to productionalize (use alternative secrets management, manage agent with Terraform, observability, etc.)
+Basic settings are not meant for a production installation. See [Advanced Configuration](#advanced-configuration) for production options such as using alternative secrets management, managing the RNA with Terraform, and configuring observability.
 
 ```shell
-# Put your client credentials in a kubernetes secret (see advanced configuration for more secrets management options)
+# Put your Client Credentials in a Kubernetes secret (see advanced configuration for more secrets management options).
+# Replace client-secret with your Client Secret and client-id with your Client Id.
+# Replace <agent-identifier> with a unique name that identifies the Kubernetes cluster where you are installing the RNA.
 kubectl --namespace armory-rna create secret generic rna-client-credentials --type=string --from-literal=client-secret=xxx-yyy-ooo --from-literal=client-id=zzz-ooo-qqq
 # Install or Upgrade armory rna chart
 helm upgrade --install armory-rna remote-network-agent \
     --repo 'https://armory.jfrog.io/artifactory/charts' \
     --set clientId='encrypted:k8s!n:rna-client-credentials!k:client-id' \
     --set clientSecret='encrypted:k8s!n:rna-client-credentials!k:client-secret' \
-    --set agentIdentifier=fieldju-microk8s-cluster \
+    --set agentIdentifier=<agent-identifier> \
     --namespace armory-rna
 ```
 
@@ -34,9 +36,8 @@ Copy, read, and then edit the [values.yaml](values.yaml) file to configure advan
 - Log Configuration
   - output type (json vs human-readable text), level, color settings
 - Disable kubernetes cluster mode
-- etc 
 
-Install using a custom values file.
+Install using a custom values file:
 
 ```shell
 # Install or Upgrade armory rna chart
@@ -47,7 +48,7 @@ helm upgrade --install \
     --namespace armory-rna
 ```
 
-Alternatively manage the agent with [Terraform with your Infrastructure as Code (IaC)](https://registry.terraform.io/providers/hashicorp/helm/latest/docs/resources/release)
+Alternately, you can manage the RNA with [Terraform with your Infrastructure as Code (IaC)](https://registry.terraform.io/providers/hashicorp/helm/latest/docs/resources/release)
 
 ```hcl
 resource "helm_release" "armory-rna" {
@@ -63,11 +64,10 @@ resource "helm_release" "armory-rna" {
 ## Observability
 
 ### Metrics
-The agent exposes an endpoint on `:8080/metrics` that is can serve prometheus or open-metrics format.
 
-If you have a prometheus or open-metrics scrapper installed in your cluster such as one of the following:
+The RNA exposes an endpoint on `:8080/metrics` that can serve Prometheus or OpenMetrics format.
 
-You can enable the following annotations in you custom values file.
+If you have a Prometheus or OpenMetrics scraper installed in your cluster, you can enable the following annotations in your custom values file:
 
 ```yaml
  podAnnotations:
@@ -79,7 +79,7 @@ You can enable the following annotations in you custom values file.
 
 ### Logging
 
-By default the agent logs in a human-readable text, but you can enable structured json logging, which is often more appropriate for log aggregation (splunk, newrelic, etc)
+By default the RNA logs in human-readable text. However, you can enable structured JSON logging, which is often more appropriate for log aggregation by tools like Splunk and New Relic.
 
 ```yaml
 log:
@@ -89,13 +89,13 @@ log:
 
 # Development
 
-## Testing / TDD'ing
+## Testing / TDDing
 
-This project uses [unnitest helm plugin](https://github.com/quintush/helm-unittest) for unit testing, see its docs. 
+This project uses [helm-unittest](https://github.com/quintush/helm-unittest) for unit testing. See its repo docs for details. 
 
 ```bash
 # requires docker and node
 make check
 ```
 
-You can also configure a values file in [scratch/values.yaml](scratch/values.yaml) and run [render.sh](render.sh) and it will produce  [scratch/manifests.yaml](scratch/manifests.yaml)
+You can also configure a values file in [scratch/values.yaml](scratch/values.yaml) and run [render.sh](render.sh) to produce  [scratch/manifests.yaml](scratch/manifests.yaml).

--- a/get-armory-rna
+++ b/get-armory-rna
@@ -1,15 +1,15 @@
 #!/usr/bin/env bash
 
 ###
-# Ensure that the system has helm installed, since RNA is installed via a helm chart
+# Ensure that the system has Helm installed, since the RNA is installed via a Helm chart
 ##
 verify_that_helm_is_installed() {
   if ! command -v helm > /dev/null; then
     echo "Not found."
     echo "======================================================================================================"
-    echo " Please install helm  https://helm.sh/docs/intro/install/ and ensure that it is on your path."
+    echo " Please install Helm  https://helm.sh/docs/intro/install/ and ensure that it is on your path."
     echo ""
-    echo " Restart after installing helm."
+    echo " Restart after installing Helm."
     echo "======================================================================================================"
     echo ""
     exit 1
@@ -23,8 +23,8 @@ verify_that_helm_is_installed() {
 }
 
 ###
-# Ensure that the system has kubernetes installed, since we store RNA's OIDC Client ID and
-# Client Secret as a kubernetes Secret
+# Ensure that the system has Kubernetes installed, since we store the RNA's Client ID and
+# Client Secret as a Kubernetes Secret
 ##
 verify_that_kubectl_is_installed() {
     if ! command -v kubectl > /dev/null; then
@@ -59,12 +59,12 @@ main() {
 
   CLIENT_ID="${2}"
   if [[ -z "$CLIENT_ID" ]]; then
-      read -r -p "Enter your OIDC Client ID for your RNA installation: " CLIENT_ID
+      read -r -p "Enter your Client ID for your RNA installation: " CLIENT_ID
   fi
 
   CLIENT_SECRET="${3}"
   if [[ -z "$CLIENT_SECRET" ]]; then
-      read -r -s -p "Enter your OIDC Client Secret for your RNA installation: " CLIENT_SECRET
+      read -r -s -p "Enter your Client Secret for your RNA installation: " CLIENT_SECRET
   fi
 
   helm repo add armory https://armory.jfrog.io/artifactory/charts

--- a/values.yaml
+++ b/values.yaml
@@ -74,7 +74,6 @@ proxy:
 # The RNA then registers itself as a deployable Kubernetes target from within CD-as-a-Service.
 #
 # When Kubernetes cluster account mode is disabled, the RNA only allows you to make network calls to networked resources.
-# You have to configure Kubernetes accounts in the CD-as-a-Service Console to have deployable Kubernetes targets.
 kubernetes:
   enableClusterAccountMode: true
   # RBAC permissions granted to the ServiceAccount for the RNA

--- a/values.yaml
+++ b/values.yaml
@@ -1,29 +1,29 @@
-# clientId and clientSecret are your Armory Cloud Client Credentials, they must have the `connect:agentHub` scope
-# Go to https://console.cloud.armory.io/configuration/credentials to create credentials or add the scope, if you haven't
+# clientId and clientSecret are your CD-as-a-Service Client Credentials, which must have the `Remote Network Agent` scope.
+# Go to https://console.cloud.armory.io/configuration/credentials to create credentials or add the scope.
 #
-# You can configure the client id and secret using any Armory Enterprise Secrets token.
+# You can configure the clientId and clientSecret using a Kubernetes secret or an Armory Continuous Deployment Secrets token.
 #
-# EX: using kubernetes secrets
-# Save the client credentials as a kubernetes secret
-# kubectl -ns armory-remote-network-agent create secret generic rna-client-credentials --type=string --from-literal=client-secret=xxx-yyy-ooo --from-literal=client-id=zzz-ooo-qqq
-# Set the clientSecret value as
+# EX: using Kubernetes secrets
+# Save your Client Credentials as a Kubernetes secret
+# kubectl -ns armory-rna create secret generic rna-client-credentials --type=string --from-literal=client-secret=xxx-yyy-ooo --from-literal=client-id=zzz-ooo-qqq
+# Set the clientSecret value as:
 # clientSecret: encrypted:k8s!n:rna-client-credentials!k:client-secret
 #
-# EX: using AWS secrets manager
+# EX: using AWS Secrets Manager
 # ex: clientSecret: encrypted:secrets-manager!r:us-west-2!s:some-aws-sm-secret-name!k:client-secret
 # See:
-# - https://docs.armory.io/armory-enterprise/armory-admin/secrets/
-# - https://docs.armory.io/armory-enterprise/armory-admin/secrets/secrets-kubernetes/ (ignore the note saying it only works with operator, it has been back ported to RNA)
-# - https://docs.armory.io/armory-enterprise/armory-admin/secrets/secrets-vault/
-# - https://docs.armory.io/armory-enterprise/armory-admin/secrets/secrets-aws-sm/
-# - https://docs.armory.io/armory-enterprise/armory-admin/secrets/secrets-gcs/
-# - https://docs.armory.io/armory-enterprise/armory-admin/secrets/secrets-s3/
+# - https://docs.armory.io/continuous-deployment/armory-admin/secrets/
+# - https://docs.armory.io/continuous-deployment/armory-admin/secrets/secrets-kubernetes/ (ignore the note saying it only works with Operator; it has been back ported to RNA)
+# - https://docs.armory.io/continuous-deployment/armory-admin/secrets/secrets-vault/
+# - https://docs.armory.io/continuous-deployment/armory-admin/secrets/secrets-aws-sm/
+# - https://docs.armory.io/continuous-deployment/armory-admin/secrets/secrets-gcs/
+# - https://docs.armory.io/continuous-deployment/armory-admin/secrets/secrets-s3/
 #
-# If you have a process for injecting secrets as env vars, such as a vault injector sidecar, you can set the client secret to an env var here.
+# If you have a process for injecting secrets as env vars, such as a vault injector sidecar, you can set the clientSecret to an env var here.
 # ex: clientSecret: '{{ env.MY_CLIENT_SECRET }}'
 # ex: https://www.vaultproject.io/docs/platform/k8s/injector
 #
-# It is NOT recommended that you use the plain-text value of your client secret in the values file or as an arg to the helm chart
+# Do NOT use the plain text value of clientSecret in the values file or as an arg to the Helm chart!
 clientId:
 clientSecret:
 
@@ -32,8 +32,8 @@ clientSecret:
 # All settings below this line are optional
 #
 #############################################################################
-# Defaults to the name used when creating the credentials for this agent.
-# This is that name that pipelines must reference to deploy to the cluster that the agent is running in.
+# Defaults to the name used when creating the Client Credentials for this RNA.
+# This is that name that your CD-as-a-Service deployment references to deploy to the cluster that the RNA is running in.
 agentIdentifier:
 
 replicaCount: 2
@@ -48,8 +48,8 @@ image:
 #  - name: regcred
 imagePullSecrets: []
 
-# Proxy settings if the agent needs to go through a proxy to connect the agent-hub
-# See below comments or the following for more technical information:
+# Proxy settings if the RNA needs to go through a proxy to connect the Agent Hub
+# See the comments below or the following for more technical information:
 # - https://github.com/grpc/grpc-go/blob/master/Documentation/proxy.md
 # - https://pkg.go.dev/golang.org/x/net/http/httpproxy#FromEnvironment
 proxy:
@@ -69,30 +69,30 @@ proxy:
   # A best effort is made to parse the string and errors are ignored.
   nonProxyHosts:
 
-# When Kubernetes cluster account mode enabled, it will create a service account, cluster role, and cluster role binding
-# The created service account w/ cluster role binding is applied to the agent.
-# The agent then registers its self as a deployable Kubernetes target from within Armory Cloud.
+# When Kubernetes cluster account mode is enabled, installation creates a ServiceAccount, ClusterRole, and ClusterRoleBinding.
+# The created ServiceAccount with ClusterRoleBinding is applied to the RNA.
+# The RNA then registers itself as a deployable Kubernetes target from within CD-as-a-Service.
 #
-# When Kubernetes cluster account mode is disabled, the agent only allows you to make network calls to networked resources.
-# You will have to configure Kubernetes Accounts in the Armory Cloud Console to have deployable Kubernetes targets.
+# When Kubernetes cluster account mode is disabled, the RNA only allows you to make network calls to networked resources.
+# You have to configure Kubernetes accounts in the CD-as-a-Service Console to have deployable Kubernetes targets.
 kubernetes:
   enableClusterAccountMode: true
-  # RBAC permissions that will be granted to the service account for the agent
+  # RBAC permissions granted to the ServiceAccount for the RNA
   clusterRoleRules:
     - apiGroups: [ "*" ]
       resources: [ "*" ]
       verbs: [ "*" ]
   serviceAccount:
-    # Annotations to add to the service account
+    # Annotations to add to the ServiceAccount
     annotations: {}
 
-# Additional environment variables to add to the pods
+# Additional environment variables to add to the Pods
 # podEnvironmentVariables:
 #  - name: FOO
 #    value: bar
 podEnvironmentVariables: []
 
-# Additional labels to add to the pods:
+# Additional labels to add to the Pods:
 # podLabels:
 #   key: value
 podLabels: {}
@@ -105,7 +105,7 @@ log:
   # debug,info,warn,error
   level: info
 
-# Additional annotations for pods
+# Additional annotations for Pods
 # podAnnotations:
 #   prometheus.io/scrape: "true"
 #   prometheus.io/path: "/metrics"
@@ -114,7 +114,7 @@ log:
 #   key: value
 podAnnotations: {}
 
-# configure pod resource requests and limits
+# Configure Pod resource requests and limits
 # https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#requests-and-limits
 resources: {}
   # limits:
@@ -124,25 +124,25 @@ resources: {}
   #   cpu: 100m
   #   memory: 256Mi
 
-# Sets pod's priorityClassName.
+# Sets Pod's priorityClassName.
 priorityClassName: ""
 
-# Sets the agent's pod dns policy
+# Sets the RNA's Pod DNS policy
 # https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-s-dns-policy
 dnsPolicy:
 
-# Sets pod's dnsConfig.
+# Sets Pod's dnsConfig.
 # https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-dns-config
 dnsConfig: {}
 
-# Sets pod/node affinities.
+# Sets Pod/Node affinities.
 # https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity
 affinity: {}
 
-# Sets pod's node selector.
+# Sets Pod's node selector.
 # https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity
 nodeSelector: {}
 
-# Sets pod's tolerations to node taints.
+# Sets Pod's tolerations to node taints.
 # https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
 tolerations: []


### PR DESCRIPTION
Proofread and update comments 

* updated links to existing CDSH docs
* standard terms 

In the CDaaS docs, I can display the contents values.yml using a custom shortcode. That's probably a better approach than duplicating the config settings in markdown.

Most, if not all, of the README is great content for the advanced install page (which you will have the pleasure of reviewing when the PR is ready). 


Partial: [CDAAS-2581]

[CDAAS-2581]: https://armory.atlassian.net/browse/CDAAS-2581?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ